### PR TITLE
[feature] Add support for custom go binary name for build.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,6 +10,10 @@ GO_BUILDTAGS="${GO_BUILDTAGS-} netgo osusergo static_build kvformat timetzdata"
 GO_LDFLAGS="${GO_LDFLAGS-} -s -w -extldflags '-static' -X 'main.Version=${VERSION:-$(git describe --tags --abbrev=0)}'"
 GO_GCFLAGS=${GO_GCFLAGS-}
 
+# Handle $GO_BIN default
+[ -z "$GO_BIN" ] && \
+    GO_BIN="go"
+
 # Maintain old $DEBUG compat.
 [ ! -z "$DEBUG" ] && \
     GO_BUILDTAGS="${GO_BUILDTAGS} debugenv"
@@ -25,7 +29,7 @@ GO_GCFLAGS=${GO_GCFLAGS-}
 # - moderncsqlite3: reverts to using the C-to-Go transpiled SQLite driver          (disables the WASM-based SQLite driver)
 # - nowasm:         [UNSUPPORTED] removes all WebAssembly from builds including 
 #                   ffmpeg, ffprobe and SQLite (instead falling back to modernc).
-log_exec env CGO_ENABLED=0 go build -trimpath -v \
+log_exec env CGO_ENABLED=0 "$GO_BIN" build -trimpath -v \
                        -tags "${GO_BUILDTAGS}" \
                        -ldflags="${GO_LDFLAGS}" \
                        -gcflags="${GO_GCFLAGS}" \


### PR DESCRIPTION
# Description

I apologize I couldn't open an issue. So I'm submitting this PR. This is a small change, so I hope it's ok.

On FreeBSD, for example, go binary installed from repo has different name (not `go` as the script currently assumes):

```sh
$ uname -rs
FreeBSD 14.1-RELEASE-p5
$ which go
$ which go121
/usr/local/bin/go121
```

So running build.sh shows `env: go: No such file or directory`.

This PR allows passing `GO_BIN` to solve it:

```sh
GO_BIN="go121" GO_BUILDTAGS="moderncsqlite3" scripts/build.sh
```

closes #(issue)
closes #(another issue)

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [ ] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
